### PR TITLE
Update papermill version to avoid nbconvert bug with nbconvert>=5.6

### DIFF
--- a/notebooks/gcp-notebook-executor/notebook_executor.sh
+++ b/notebooks/gcp-notebook-executor/notebook_executor.sh
@@ -10,7 +10,7 @@ fi
 
 if [[ ! -z $(command -v conda) ]]; then
   source /opt/anaconda3/bin/activate base
-  sudo /opt/anaconda3/bin/pip install -U papermill==0.19.1
+  sudo /opt/anaconda3/bin/pip install -U papermill>=1.0.1
 fi
 
 readonly INPUT_NOTEBOOK_GCS_FILE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/input_notebook -H "Metadata-Flavor: Google")


### PR DESCRIPTION
There was an nbconvert update in nbconvert=>5.6 which add an argument to `run_cell`, which makes papermill < 1.0.1 fail on notebook execution

```
File "/opt/miniconda/lib/python3.6/site-packages/papermill/preprocess.py", line 27, in preprocess
nb, resources = self.papermill_process(nb_man, resources)
File "/opt/miniconda/lib/python3.6/site-packages/papermill/preprocess.py", line 76, in papermill_process
nb.cells[index], resources = self.preprocess_cell(cell, resources, index)
File "/opt/miniconda/lib/python3.6/site-packages/nbconvert/preprocessors/execute.py", line 438, in preprocess_cell
reply, outputs = self.run_cell(cell, cell_index, store_history)
TypeError: run_cell() takes from 2 to 3 positional arguments but 4 were given
```

This issue has been resolved with papermill versions above 1.0.1

Ref: 
Nbconvert PR: https://github.com/jupyter/nbconvert/pull/1055/
Papermill issue: https://github.com/nteract/papermill/issues/410

The following PR upgrades papermill to >=1.0.1, which should solve the issue (at least on the use cases I ran)
