### PR TITLE
remove user prompt while installing sysstat

### DIFF
--- a/notebooks/tools/auto-shutdown/install.sh
+++ b/notebooks/tools/auto-shutdown/install.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ==============================================================================
 
-apt-get install sysstat bc
+apt-get --assume-yes install sysstat bc
 cp ./ashutdown /usr/local/bin/
 cp ./ashutdown.service /lib/systemd/system/
 systemctl --no-reload --now enable /lib/systemd/system/ashutdown.service


### PR DESCRIPTION
We would like to install the script without a user prompt