### PR TITLE
Prevent Cloud Storage bucket name from getting corrupted

### DIFF
--- a/training/pytorch/structured/custom_containers/base/trainer/inputs.py
+++ b/training/pytorch/structured/custom_containers/base/trainer/inputs.py
@@ -121,9 +121,12 @@ def save_model(args):
     Args:
       args: contains name for saved model.
     """
-    bucket_name = args.job_dir.lstrip('gs://').split('/')[0]
-    bucket_path = args.job_dir.lstrip(
-        'gs://{}/'.format(bucket_name)).rstrip('/')
+    scheme = 'gs://'
+    bucket_name = args.job_dir[len(scheme):].split('/')[0]
+
+    prefix = '{}{}/'.format(scheme, bucket_name)
+    bucket_path = args.job_dir[len(prefix):].rstrip('/')
+
     datetime_ = datetime.datetime.now().strftime('model_%Y%m%d_%H%M%S')
 
     if bucket_path:

--- a/training/pytorch/structured/custom_containers/gpu/trainer/inputs.py
+++ b/training/pytorch/structured/custom_containers/gpu/trainer/inputs.py
@@ -125,9 +125,12 @@ def save_model(args):
     Args:
       args: contains name for saved model.
     """
-    bucket_name = args.job_dir.lstrip('gs://').split('/')[0]
-    bucket_path = args.job_dir.lstrip(
-        'gs://{}/'.format(bucket_name)).rstrip('/')
+    scheme = 'gs://'
+    bucket_name = args.job_dir[len(scheme):].split('/')[0]
+
+    prefix = '{}{}/'.format(scheme, bucket_name)
+    bucket_path = args.job_dir[len(prefix):].rstrip('/')
+
     datetime_ = datetime.datetime.now().strftime('model_%Y%m%d_%H%M%S')
 
     if bucket_path:

--- a/training/pytorch/structured/python_package/trainer/inputs.py
+++ b/training/pytorch/structured/python_package/trainer/inputs.py
@@ -127,9 +127,10 @@ def save_model(args):
     Args:
       args: contains name for saved model.
     """
-    bucket_name = args.job_dir.lstrip('gs://').split('/')[0]
+    scheme = 'gs://'
+    bucket_name = args.job_dir[len(scheme):].split('/')[0]
 
-    prefix = 'gs://{}/'.format(bucket_name)
+    prefix = '{}{}/'.format(scheme, bucket_name)
     bucket_path = args.job_dir[len(prefix):].rstrip('/')
 
     datetime_ = datetime.datetime.now().strftime('model_%Y%m%d_%H%M%S')


### PR DESCRIPTION
[`lstrip`](https://docs.python.org/3/library/stdtypes.html#str.lstrip):

> The chars argument is a string specifying the set of characters to be removed. … The chars argument is not a prefix; rather, all combinations of its values are stripped

This was having an unintended effect: If the bucket name started with the letter `g` or `s`, those letters would get removed, corrupting the bucket name.