### PR TITLE
Added check for the testing environment to prevent  failure when testing.

### DIFF
--- a/ai-platform-unified/notebooks/notebook_template.ipynb
+++ b/ai-platform-unified/notebooks/notebook_template.ipynb
@@ -338,7 +338,7 @@
         "    # If you are running this notebook locally, replace the string below with the\n",
         "    # path to your service account key and run this cell to authenticate your GCP\n",
         "    # account.\n",
-        "    else:\n",
+        "    elif not os.getenv(\"IS_TESTING\"):\n",
         "        %env GOOGLE_APPLICATION_CREDENTIALS ''"
       ]
     },


### PR DESCRIPTION
Replaced

```
if not os.getenv("IS_TESTING"):
        %env GOOGLE_APPLICATION_CREDENTIALS ''
```

with

```
elif not os.getenv("IS_TESTING"):
        %env GOOGLE_APPLICATION_CREDENTIALS ''
```
