### PR TITLE
Fix vertex featurestore notebook on colab 

### DIFF
--- a/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
+++ b/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
@@ -157,7 +157,9 @@
         "# Install the latest public release version\n",
         "# !pip install -U google-cloud-aiplatform\n",
         "# Install the testing version\n",
-        "!pip install git+https://github.com/googleapis/python-aiplatform.git@main-test"
+        "!pip install git+https://github.com/googleapis/python-aiplatform.git@main-test\n",
+        "# Install latest version of BigQuery (google colab is 1.21.0 which is very old and does not support the timeout parameter)\n",
+        "!pip install --upgrade google-cloud-bigquery"
       ]
     },
     {
@@ -276,6 +278,16 @@
       "source": [
         "if PROJECT_ID == \"\" or PROJECT_ID is None:\n",
         "    PROJECT_ID = \"python-docs-samples-tests\"  # @param {type:\"string\"}"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Add project ID into environment so Bigquery client can read it later\n",
+        "os.environ['GCLOUD_PROJECT'] = PROJECT_ID"
       ]
     },
     {

--- a/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
+++ b/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
@@ -198,11 +198,7 @@
         "id": "lWEdiXsJg0XY"
       },
       "source": [
-        "## Before you begin\n",
-        "\n",
-        "### Select a GPU runtime\n",
-        "\n",
-        "**Make sure you're running this notebook in a GPU runtime if you have that option. In Colab, select \"Runtime --> Change runtime type > GPU\"**"
+        "## Before you begin"
       ]
     },
     {

--- a/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
+++ b/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
@@ -159,7 +159,7 @@
         "# Install the testing version\n",
         "!pip install git+https://github.com/googleapis/python-aiplatform.git@main-test\n",
         "# Install latest version of BigQuery (google colab is 1.21.0 which is very old and does not support the timeout parameter)\n",
-        "!pip install --upgrade google-cloud-bigquery"
+        "!pip install --upgrade google-cloud-bigquery==2.17.0"
       ]
     },
     {


### PR DESCRIPTION
The VertexAI Featurestore notebook had some issues when running on a Colab instance. I wasn't able to run all cells in succession, so several things have been addressed:

- Colab uses BigQuery version 1.21.0, which is out of date and did not have the `timeout` parameter which was used in one of the cells
- When using OAuth, the project ID is not known and was not properly set, causing the BigQuery client to fail. Was fixed by adding it in the environment when first entered by the user
- The `display_name` argument has recently been changed to just `name` in the SDK. Changed here too.
- Removed the notice to add a GPU to the instance, it is not needed in this notebook

These changes allowed me to run all cells in succession on Google Colab without issue.