### PR TITLE
Small fix to pipeline name

### DIFF
--- a/ai-platform-unified/notebooks/unofficial/pipelines/automl_tabular_classification_beans.ipynb
+++ b/ai-platform-unified/notebooks/unofficial/pipelines/automl_tabular_classification_beans.ipynb
@@ -965,7 +965,7 @@
       "source": [
         "### Extract metrics and parameters into a pandas dataframe for run comparison\n",
         "\n",
-        "Ingest the metadata for all runs of pipelines named `automl-tab-comments-training-v2` into a pandas dataframe."
+        "Ingest the metadata for all runs of pipelines named `automl-tab-beans-training-v2` into a pandas dataframe."
       ]
     },
     {
@@ -989,7 +989,7 @@
       },
       "outputs": [],
       "source": [
-        "pipeline_df = aiplatform.get_pipeline_df(pipeline=\"automl-tab-comments-training-v2\")\n",
+        "pipeline_df = aiplatform.get_pipeline_df(pipeline=\"automl-tab-beans-training-v2\")\n",
         "small_pipeline_df = pipeline_df.head(2)\n",
         "small_pipeline_df"
       ]


### PR DESCRIPTION
Changing typo from "automl-tab-comments-training-v2" to "automl-tab-beans-training-v2"