### PR TITLE
Update the Dockerfile for MNIST custom container training to fix #390

### DIFF
--- a/training/horovod/mnist/Dockerfile
+++ b/training/horovod/mnist/Dockerfile
@@ -15,4 +15,4 @@ RUN git clone --depth 1 https://github.com/horovod/horovod.git && \
 
 WORKDIR /output
 
-CMD ["python", "/infra/examples/keras_mnist.py"]
+CMD ["python", "/infra/examples/keras/keras_mnist.py"]


### PR DESCRIPTION
The custom container image for MNIST training example was broken due to the directory change in Horovod repository #390.

This PR fixes the directory path in the Dockerfile for the script that runs a Horovod distributed training with Keras.

Tested: Launch a successful CAIP job 
```
MODEL_NAME=mnist GCS_OUTPUT_PATH=gs://$BUCKET ./training/horovod/scripts/train-cloud.sh
```