### PR TITLE
Update the GCS URI to latest test data with corrected timestamp

### DIFF
--- a/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
+++ b/ai-platform-unified/notebooks/official/feature_store/gapic-feature-store.ipynb
@@ -456,7 +456,7 @@
       "source": [
         "# Other than project ID and featurestore ID and endpoints needs to be set\n",
         "API_ENDPOINT = \"us-central1-aiplatform.googleapis.com\"  # @param {type:\"string\"}\n",
-        "INPUT_CSV_FILE = \"gs://cloud-samples-data-us-central1/ai-platform-unified/datasets/featurestore/movie_prediction.csv\""
+        "INPUT_CSV_FILE = \"gs://cloud-samples-data-us-central1/vertex-ai/feature-store/datasets/movie_prediction.csv\""
       ]
     },
     {
@@ -951,7 +951,7 @@
         "        # Source\n",
         "        gcs_source=io_pb2.GcsSource(\n",
         "            uris=[\n",
-        "                \"gs://cloud-samples-data-us-central1/ai-platform-unified/datasets/featurestore/users.avro\"\n",
+        "                \"gs://cloud-samples-data-us-central1/vertex-ai/feature-store/datasets/users.avro\"\n",
         "            ]\n",
         "        )\n",
         "    ),\n",
@@ -1019,7 +1019,7 @@
         "    avro_source=io_pb2.AvroSource(\n",
         "        gcs_source=io_pb2.GcsSource(\n",
         "            uris=[\n",
-        "                \"gs://cloud-samples-data-us-central1/ai-platform-unified/datasets/featurestore/movies.avro\"\n",
+        "                \"gs://cloud-samples-data-us-central1/vertex-ai/feature-store/datasets/movies.avro\"\n",
         "            ]\n",
         "        )\n",
         "    ),\n",


### PR DESCRIPTION
This update is necessary to ensure the legacy notebook is still working after a new feature is pushed to prod.
