### PR TITLE
Fix matching engine notebook deleting GCS bucket

### DIFF
--- a/ai-platform-unified/notebooks/unofficial/matching_engine/matching_engine_for_indexing.ipynb
+++ b/ai-platform-unified/notebooks/unofficial/matching_engine/matching_engine_for_indexing.ipynb
@@ -541,7 +541,7 @@
       "source": [
         "# NOTE: Everything in this GCS DIR will be DELETED before uploading the data.\n",
         "\n",
-        "! gsutil rm -rf {BUCKET_NAME}"
+        "! gsutil rm {BUCKET_NAME}/**"
       ]
     },
     {


### PR DESCRIPTION
rm -rf will [delete the bucket too](https://cloud.google.com/storage/docs/gsutil/commands/rm#description). Use gsutil `rm gs://bucket/subdir/**` instead

----------------------------------------------------------------------------------------------------
ATTENTION: 

If you are opening a PR to check in content under the folder [`ai-platform-unified/`](https://github.com/GoogleCloudPlatform/ai-platform-samples/tree/master/ai-platform-unified), please close this PR, and open your PR in the new content repository [GoogleCloudPlatform/vertex-ai-samples](https://github.com/googlecloudplatform/vertex-ai-samples).

----------------------------------------------------------------------------------------------------

Before submitting a Jupyter notebook, follow this mandatory checklist:

- [ ] Use the [notebook template](https://github.com/GoogleCloudPlatform/ai-platform-samples/blob/master/ai-platform-unified/notebooks/notebook_template.ipynb) as a starting point.
- [ ] Double check that all links, including the Colab and Github links to the notebook, are valid.
- [ ] Follow the style and grammar rules outlined in the above notebook template.
- [ ] Verify the notebook runs successfully in Colab since the automated tests cannot guarantee this even when it passes.
- [ ] Passes all the required automated checks
- [ ] You have consulted with a tech writer to see if tech writer review is necessary. If so, the notebook has been reviewed by a tech writer, and they have approved it.
- [ ] This notebook has been added to the CODEOWNERS file, pointing to the author or the author's team. If the CODEOWNERS file doesn't exist, create one in the nearest folder that makes sense.
- [ ] The Jupyter notebook cleans up any artifacts it has created (datasets, ML models, endpoints, etc) so as not to eat up unnecessary resources.
