### PR TITLE
Use V100 and Reduction Server by default

### DIFF
--- a/training/horovod/README.md
+++ b/training/horovod/README.md
@@ -23,7 +23,7 @@ Run the following script to run MNIST training job on AI Platform:
 MODEL_NAME=mnist GCS_OUTPUT_PATH=<GCS_BUCKET> scripts/train-cloud.sh
 ```
 
-By default, the script `train-cloud.sh` uses 2 `n1-highmem-96` machines with 4 `nvidia-tesla-t4` GPUs on each machine. Variables `MACHINE_TYPE`, `MACHINE_COUNT`, `GPU_TYPE`, `GPU_COUNT` configure these settings. 
+By default, the script `train-cloud.sh` uses 2 `n1-highmem-96` machines with 8 `nvidia-tesla-v100` GPUs on each machine. Variables `MACHINE_TYPE`, `MACHINE_COUNT`, `GPU_TYPE`, `GPU_COUNT` configure these settings. 
 
 ### MaskRCNN with Tensorpack
 

--- a/training/horovod/base/Dockerfile
+++ b/training/horovod/base/Dockerfile
@@ -6,7 +6,7 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - &
     apt-get update && \
     apt-get remove -y google-fast-socket && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends --allow-change-held-packages \
-        iperf openssh-client openssh-server cuda-toolkit-11-3 libnccl2 libnccl-dev cmake google-reduction-server && \
+        iperf openssh-client openssh-server cmake google-reduction-server && \
     ldconfig /usr/local/cuda/targets/x86_64-linux/lib && \
     HOROVOD_GPU_OPERATIONS=NCCL HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITH_GLOO=1 \
          pip install --no-cache-dir horovod && \

--- a/training/horovod/scripts/train-cloud.sh
+++ b/training/horovod/scripts/train-cloud.sh
@@ -30,10 +30,10 @@ MACHINE_TYPE=${MACHINE_TYPE:-n1-highmem-96}
 MACHINE_COUNT=${MACHINE_COUNT:-2}
 
 # GPU_TYPE: type of GPU
-GPU_TYPE=${GPU_TYPE:-nvidia-tesla-t4}
+GPU_TYPE=${GPU_TYPE:-nvidia-tesla-v100}
 
 # GPU_COUNT: number of GPUs per machine
-GPU_COUNT=${GPU_COUNT:-4}
+GPU_COUNT=${GPU_COUNT:-8}
 
 # IMAGE_REPO_NAME: the image will be stored on Cloud Container Registry
 IMAGE_REPO_NAME=horovod_${MODEL_NAME}

--- a/training/horovod/scripts/train-vertex.sh
+++ b/training/horovod/scripts/train-vertex.sh
@@ -29,14 +29,18 @@ MACHINE_TYPE=${MACHINE_TYPE:-n1-highmem-96}
 # MACHINE_COUNT: number of workers (master included)
 MACHINE_COUNT=${MACHINE_COUNT:-2}
 
-# REDUCER_COUNT: number of reducers
-REDUCER_COUNT=${REDUCER_COUNT:-0}
-
 # GPU_TYPE: type of GPU
-GPU_TYPE=${GPU_TYPE:-NVIDIA_TESLA_T4}
+GPU_TYPE=${GPU_TYPE:-NVIDIA_TESLA_V100}
 
 # GPU_COUNT: number of GPUs per machine
-GPU_COUNT=${GPU_COUNT:-4}
+GPU_COUNT=${GPU_COUNT:-8}
+
+# REDUCER_COUNT: number of reducers
+if [ "${GPU_COUNT}" -gt "0" ]; then
+    REDUCER_COUNT=${REDUCER_COUNT:-$((MACHINE_COUNT * 3))}
+else
+    REDUCER_COUNT=0
+fi
 
 # IMAGE_REPO_NAME: the image will be stored on Cloud Container Registry
 IMAGE_REPO_NAME=horovod_${MODEL_NAME}


### PR DESCRIPTION
* Use V100 instead of T4 by default.
* Turn on Reduction Server if training on multi-host GPUs. Use 3x `MACHINE_COUNT` as `REDUCER_COUNT` unless specified otherwise.

/cc @sshrdp 